### PR TITLE
Worker nprocs handling: read nprocs correctly as int

### DIFF
--- a/r.dop.import.worker.bb.be/r.dop.import.worker.bb.be.py
+++ b/r.dop.import.worker.bb.be/r.dop.import.worker.bb.be.py
@@ -159,7 +159,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.bb.be/r.dop.import.worker.bb.be.py
+++ b/r.dop.import.worker.bb.be/r.dop.import.worker.bb.be.py
@@ -157,9 +157,9 @@ def main():
     keep_data = flags["k"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.bw/r.dop.import.worker.bw.py
+++ b/r.dop.import.worker.bw/r.dop.import.worker.bw.py
@@ -156,9 +156,9 @@ def main():
     new_mapset = options["new_mapset"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.bw/r.dop.import.worker.bw.py
+++ b/r.dop.import.worker.bw/r.dop.import.worker.bw.py
@@ -158,7 +158,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.by/r.dop.import.worker.by.py
+++ b/r.dop.import.worker.by/r.dop.import.worker.by.py
@@ -151,7 +151,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.by/r.dop.import.worker.by.py
+++ b/r.dop.import.worker.by/r.dop.import.worker.by.py
@@ -149,9 +149,9 @@ def main():
     new_mapset = options["new_mapset"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.he/r.dop.import.worker.he.py
+++ b/r.dop.import.worker.he/r.dop.import.worker.he.py
@@ -151,9 +151,9 @@ def main():
     new_mapset = options["new_mapset"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.he/r.dop.import.worker.he.py
+++ b/r.dop.import.worker.he/r.dop.import.worker.he.py
@@ -153,7 +153,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.hh/r.dop.import.worker.hh.py
+++ b/r.dop.import.worker.hh/r.dop.import.worker.hh.py
@@ -158,9 +158,9 @@ def main():
     keep_data = flags["k"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.hh/r.dop.import.worker.hh.py
+++ b/r.dop.import.worker.hh/r.dop.import.worker.hh.py
@@ -160,7 +160,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.ni/r.dop.import.worker.ni.py
+++ b/r.dop.import.worker.ni/r.dop.import.worker.ni.py
@@ -158,9 +158,9 @@ def main():
     keep_data = flags["k"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.ni/r.dop.import.worker.ni.py
+++ b/r.dop.import.worker.ni/r.dop.import.worker.ni.py
@@ -160,7 +160,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.nw/r.dop.import.worker.nw.py
+++ b/r.dop.import.worker.nw/r.dop.import.worker.nw.py
@@ -159,7 +159,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.nw/r.dop.import.worker.nw.py
+++ b/r.dop.import.worker.nw/r.dop.import.worker.nw.py
@@ -157,9 +157,9 @@ def main():
     keep_data = flags["k"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.rp/r.dop.import.worker.rp.py
+++ b/r.dop.import.worker.rp/r.dop.import.worker.rp.py
@@ -160,9 +160,9 @@ def main():
     keep_data = flags["k"]
 
     # check number of nprocs used and set to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.rp/r.dop.import.worker.rp.py
+++ b/r.dop.import.worker.rp/r.dop.import.worker.rp.py
@@ -162,7 +162,7 @@ def main():
     # check number of nprocs used and set to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.sn/r.dop.import.worker.sn.py
+++ b/r.dop.import.worker.sn/r.dop.import.worker.sn.py
@@ -159,7 +159,7 @@ def main():
     # check number of nprocs used and set to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.sn/r.dop.import.worker.sn.py
+++ b/r.dop.import.worker.sn/r.dop.import.worker.sn.py
@@ -157,9 +157,9 @@ def main():
     keep_data = flags["k"]
 
     # check number of nprocs used and set to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.th/r.dop.import.worker.th.py
+++ b/r.dop.import.worker.th/r.dop.import.worker.th.py
@@ -150,9 +150,9 @@ def main():
     new_mapset = options["new_mapset"]
 
     # set nprocs to 1, write original value in variable
-    gisenv = grass.parse_command("g.gisenv", get="")
+    gisenv = grass.gisenv()
     if "NPROCS" in gisenv:
-        original_nprocs = int(gisenv["NPROCS"].strip("';"))
+        original_nprocs = int(gisenv["NPROCS"])
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution

--- a/r.dop.import.worker.th/r.dop.import.worker.th.py
+++ b/r.dop.import.worker.th/r.dop.import.worker.th.py
@@ -152,7 +152,7 @@ def main():
     # set nprocs to 1, write original value in variable
     gisenv = grass.parse_command("g.gisenv", get="")
     if "NPROCS" in gisenv:
-        original_nprocs = gisenv["NPROCS"]
+        original_nprocs = int(gisenv["NPROCS"].strip("';"))
     grass.run_command("g.gisenv", set="NPROCS=1")
 
     # output resolution


### PR DESCRIPTION
Currently:
```
>>> gisenv = grass.parse_command("g.gisenv", get="")
>>> gisenv["NPROCS"]
"'1';"
```
This leads to errornous nprocs value, when reset within cleanup with `grass.run_command("g.gisenv", set=f"NPROCS={original_nprocs}")`.

Fix: parse correctly as integer.