### PR TITLE
Update resampling method: bicubic

### DIFF
--- a/r.dop.import.worker.bb.be/r.dop.import.worker.bb.be.py
+++ b/r.dop.import.worker.bb.be/r.dop.import.worker.bb.be.py
@@ -209,6 +209,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.bw/r.dop.import.worker.bw.py
+++ b/r.dop.import.worker.bw/r.dop.import.worker.bw.py
@@ -208,6 +208,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.by/r.dop.import.worker.by.py
+++ b/r.dop.import.worker.by/r.dop.import.worker.by.py
@@ -197,6 +197,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.he/r.dop.import.worker.he.py
+++ b/r.dop.import.worker.he/r.dop.import.worker.he.py
@@ -197,6 +197,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.hh/r.dop.import.worker.hh.py
+++ b/r.dop.import.worker.hh/r.dop.import.worker.hh.py
@@ -268,6 +268,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.ni/r.dop.import.worker.ni.py
+++ b/r.dop.import.worker.ni/r.dop.import.worker.ni.py
@@ -210,6 +210,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.nw/r.dop.import.worker.nw.py
+++ b/r.dop.import.worker.nw/r.dop.import.worker.nw.py
@@ -209,6 +209,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.rp/r.dop.import.worker.rp.py
+++ b/r.dop.import.worker.rp/r.dop.import.worker.rp.py
@@ -223,6 +223,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.sn/r.dop.import.worker.sn.py
+++ b/r.dop.import.worker.sn/r.dop.import.worker.sn.py
@@ -209,6 +209,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/r.dop.import.worker.th/r.dop.import.worker.th.py
+++ b/r.dop.import.worker.th/r.dop.import.worker.th.py
@@ -198,6 +198,7 @@ def main():
                 f"{raster_name_band}_tmp1",
                 raster_name_band,
                 resolution_to_import,
+                interp_method="bicubic",
                 type="CELL",
             )
             rm_rast.append(f"{raster_name_band}_tmp1")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-grass-gis-helpers>=1.1.0
+grass-gis-helpers>=2.6.0
 psutil
 wget


### PR DESCRIPTION
Update resampling method from default bilinear to bicubic, which preserves sharp borders better.

Note: requires https://github.com/mundialis/grass-gis-helpers/pull/60 