### PR TITLE
Add opendata flag for local data import

### DIFF
--- a/lib_dop/r_dop_import_lib.py
+++ b/lib_dop/r_dop_import_lib.py
@@ -607,7 +607,7 @@ def import_local_data(
             _(
                 "Local data does not overlap with AOI."
                 "Check local_data_dir or consider using o-flag.",
-            )
+            ),
         )
     elif not imported_local_data and opendata_flag:
         grass.message(

--- a/lib_dop/r_dop_import_lib.py
+++ b/lib_dop/r_dop_import_lib.py
@@ -571,6 +571,7 @@ def import_local_data(
     rm_groups,
     native_res,
     ns_res,
+    opendata_flag,
 ):
     """Import local DOP data
 
@@ -587,6 +588,8 @@ def import_local_data(
         native_res (bool): Flag to keep native resolution of imported data
                            (True, if resolution kept)
         ns_res (float): Resolution to resample imported raster to
+        opendata_flag (boolean): Flag to indicate if data should be downloaded
+                                 from Open Data portal if local data dont match
 
     """
     imported_local_data = import_local_raster_data(
@@ -599,9 +602,9 @@ def import_local_data(
         band_dict={1: "red", 2: "green", 3: "blue", 4: "nir"},
     )
 
-    if not imported_local_data and fs in ["BW"]:
+    if not imported_local_data and not opendata_flag:
         grass.fatal(_("Local data does not overlap with AOI."))
-    elif not imported_local_data:
+    elif not imported_local_data and opendata_flag:
         grass.message(
             _(
                 "Local data does not overlap with AOI. Data will be downloaded"

--- a/lib_dop/r_dop_import_lib.py
+++ b/lib_dop/r_dop_import_lib.py
@@ -605,7 +605,7 @@ def import_local_data(
     if not imported_local_data and not opendata_flag:
         grass.fatal(
             _(
-                "Local data does not overlap with AOI."
+                "Local data does not overlap with AOI. "
                 "Check local_data_dir or consider using o-flag.",
             ),
         )
@@ -654,7 +654,7 @@ def import_local_data(
                 # Note: Want real raster/no VRT as output
                 vrt_to_raster(vrt, out_band)
 
-    rasters_rescale = rescale_to_1_255("", out)
-    rm_rasters.extend(rasters_rescale)
+        rasters_rescale = rescale_to_1_255("", out)
+        rm_rasters.extend(rasters_rescale)
 
     return imported_local_data

--- a/lib_dop/r_dop_import_lib.py
+++ b/lib_dop/r_dop_import_lib.py
@@ -603,7 +603,12 @@ def import_local_data(
     )
 
     if not imported_local_data and not opendata_flag:
-        grass.fatal(_("Local data does not overlap with AOI."))
+        grass.fatal(
+            _(
+                "Local data does not overlap with AOI."
+                "Check local_data_dir or consider using o-flag.",
+            )
+        )
     elif not imported_local_data and opendata_flag:
         grass.message(
             _(

--- a/r.dop.import/r.dop.import.py
+++ b/r.dop.import/r.dop.import.py
@@ -100,7 +100,7 @@
 
 # %flag
 # % key: o
-# % description: For local data import: if no matching local data found, try to access via Open Data portal
+# % description: For local data import: if no matching local data found, try to access via open data portal
 # %end
 
 # %rules
@@ -212,7 +212,15 @@ def main():
 
         # check if local data for federal state given
         imported_local_data = False
-        if fs in local_fs_list:
+        if fs not in local_fs_list and not flags["o"]:
+            grass.fatal(
+                _(
+                    f"Missing federal state folder '{fs}' "
+                    f"within local_data_dir: '{local_data_dir}'. "
+                    "Check local_data_dir or consider using o-flag.",
+                ),
+            )
+        elif fs in local_fs_list:
             all_dops_local = []
             out_fs = f"dop_{fs}_{ID}"
             imported_local_data = import_local_data(

--- a/r.dop.import/r.dop.import.py
+++ b/r.dop.import/r.dop.import.py
@@ -98,10 +98,16 @@
 # % description: Use native data resolution
 # %end
 
+# %flag
+# % key: o
+# % description: For local data import: if no matching local data found, try to access via Open Data portal
+# %end
+
 # %rules
 # % required: federal_state, federal_state_file
 # % excludes: federal_state_file, federal_state
 # % requires_all: -k, download_dir
+# % requires: -o, local_data_dir
 # %end
 
 import atexit
@@ -219,6 +225,7 @@ def main():
                 rm_groups,
                 native_res,
                 ns_res,
+                flags["o"],
             )
             if imported_local_data:
                 for band in ("red", "green", "blue", "nir"):


### PR DESCRIPTION
For local data import:
If no matching local data found, currently data from open data portal are tried to download (except for BW).
This ist changed, such that by default the addon fails, if no matching data found from local data dir. With the `-o` flag however the old approach, trying the download from open data portal, is kept.